### PR TITLE
fixed #77

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,10 @@ const browserEnv = function () {
 
     // Copy what's left to the Node.js global scope
     .forEach(prop => {
+	// for fixing https://github.com/lukechilds/browser-env/issues/77
+	if (['Infinity', 'NaN', 'undefined'].includes(prop)) {
+		return
+	}
 	Object.defineProperty(global, prop, {
 		configurable: true,
 		get: () => window[prop]


### PR DESCRIPTION
Redefining certain properties (NaN, undefined, etc.) is not possible.

Without skipping them it throws an error, preventing to set `runScripts: 'dangerously'`